### PR TITLE
fix reset password route parameter issue

### DIFF
--- a/src/Config/Routes.php
+++ b/src/Config/Routes.php
@@ -13,7 +13,7 @@ $routes->group('', ['namespace' => 'SweetScar\AuthIgniter\Controllers'], functio
         $routes->get('forgot-password', 'AuthIgniter::forgotPassword', ['as' => 'authigniter:forgotPassword']);
         $routes->post('attempt-forgot-password', 'AuthIgniter::attemptForgotPassword', ['as' => 'authigniter:attemptForgotPassword']);
         $routes->get('reset-password', 'AuthIgniter::resetPassword', ['as' => 'authigniter:resetPassword']);
-        $routes->post('attempt-reset-password/(:any)', 'AuthIgniter::attemptResetPassword/$1', ['as' => 'authigniter:attemptResetPassword']);
+        $routes->post('attempt-reset-password', 'AuthIgniter::attemptResetPassword', ['as' => 'authigniter:attemptResetPassword']);
         $routes->get('reset-password-result', 'AuthIgniter::resetPasswordResult', ['as' => 'authigniter:resetPasswordResult']);
     }
 

--- a/src/Controllers/AuthIgniter.php
+++ b/src/Controllers/AuthIgniter.php
@@ -315,7 +315,7 @@ class AuthIgniter extends BaseController
     /**
      * Try to reset user password
      */
-    public function attemptResetPassword($resetPasswordToken)
+    public function attemptResetPassword()
     {
         // if user has logged in, redirect to base url
         if ($this->authentication->check()) return redirect()->to(base_url());
@@ -336,7 +336,7 @@ class AuthIgniter extends BaseController
         }
 
         // verify the reset password token
-        $verifyToken = $this->resetPasswordToken->verify($resetPasswordToken);
+        $verifyToken = $this->resetPasswordToken->verify($this->request->getPost('token'));
 
         if (!$verifyToken) {
             return redirect('authigniter:resetPasswordResult')->with('reset_password_result', ['type' => 'error', 'message' => $this->resetPasswordToken->getErrorMessage()]);

--- a/src/Views/reset_password.php
+++ b/src/Views/reset_password.php
@@ -13,9 +13,11 @@
                     <h4 class="text-center"><?= lang('AuthIgniter.resetPasswordPageTitle') ?></h4>
                 </div>
                 <div class="card-body">
-                    <form action="<?= route_to('authigniter:attemptResetPassword', $resetPasswordToken) ?>" method="POST">
+                    <form action="<?= route_to('authigniter:attemptResetPassword') ?>" method="POST">
 
                         <?= csrf_field() ?>
+
+                        <input type="hidden" name="token" value="<?= $resetPasswordToken ?>">
 
                         <div class="mb-3">
                             <input type="password" name="new-password" id="new-password" class="form-control <?= (session('errors.new-password')) ? 'is-invalid' : '' ?>" placeholder="<?= lang('AuthIgniter.newPassword') ?>" autofocus>


### PR DESCRIPTION
The authenticate filter when used for a group of routes caused the website to break due to the fact that in the _AuthenticationFilter.php_ the `route_to('authigniter:attemptResetPassword')` would require a second parameter and it was not provided. **I moved the password reset hash token from the url to the form as a hidden input** in order to avoid passing a meaningless empty string parameter (in the  _AuthenticationFilter.php_ at line 38).
